### PR TITLE
Add systemd service file for setting deep mode on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
 [![License](https://img.shields.io/badge/license-apache%202.0-brightgreen.svg)](https://github.com/rholder/laptop-sleep-tool/blob/master/LICENSE)
 # laptop-sleep-tool
 
-Use `laptop-sleep-tool` to show and optionally set a few sleep mode parameters on modern Linux kernels. I wrote this to quickly diagnose and check the sleep settings on laptops without having to remember which file needs to be manipulated. By itself, it does NOT permanently set the sleep mode so changes made will not persist across reboots. With this tool, one can check the current setting, switch back and forth between settings, and test whether the sleep modes are performing correctly.
+Use `laptop-sleep-tool` to show and optionally set a few sleep mode parameters on modern Linux kernels. I wrote this to quickly diagnose and check the sleep settings on laptops without having to remember which file needs to be manipulated. With this tool, one can check the current setting, switch back and forth between settings, and test whether the sleep modes are performing correctly. You can either run it manually, or install it as a systemd service to set the sleep mode to `deep` on system boot.
 
 It's been tested mostly on a few varieties of Dell XPS 13 laptops that were experiencing high battery drain during sleep using the default settings from Ubuntu 18.04 and the `4.15.x` kernel. It probably works on a bunch of other hardware, too.
 
 ## Features
 * Show current memory sleep setting
 * Set the current memory sleep setting, if run as root, to `deep` or `s2idle`
+* Optionally, run automatically on startup
 
-## Installation
+## Installation on Linux
 It's a Bash shell script that can go somewhere in your `PATH`. The latest release is available [here](https://github.com/rholder/laptop-sleep-tool/releases).
 
-### Linux
+### Install script
 Drop the script into your path, such as `/usr/local/bin`:
 ```bash
 sudo curl -o /usr/local/bin/laptop-sleep-tool -L "https://github.com/rholder/laptop-sleep-tool/releases/download/v1.0.0/laptop-sleep-tool" && \
 sudo chmod +x /usr/local/bin/laptop-sleep-tool
 ```
+
+### Start on boot
+If you also want to automatically run this script to enable `deep` sleep mode when your systemd-compatible OS starts up:
+- Run the above installation step
+- Drop the service file into `/etc/systemd/system/` and enable it with systemctl:
+```bash
+sudo curl -o /etc/systemd/system/laptop-sleep-tool.service -L "https://github.com/rholder/laptop-sleep-tool/releases/download/v1.1.0/laptop-sleep-tool.service" && \
+sudo systemctl enable laptop-sleep-tool.service
+```
+
+**:star2: Note: the service file expects the script to live in `/usr/local/bin`. If you put the script elsewhere, you will need to update the service file to match**
 
 ## Usage
 ```

--- a/laptop-sleep-tool.service
+++ b/laptop-sleep-tool.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Set laptop sleep mode to deep
+Documentation=https://github.com/rholder/laptop-sleep-tool
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/laptop-sleep-tool -md
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# :boot:

Adds a `.service` file and instructions for installing and enabling it. This allows the script to be run on boot. It's been tested!

I took the liberty of incrementing the version in the download URL for the service file only, to `1.1.0`. I didn't update the versions anywhere else.

